### PR TITLE
Remove out-of-date comment and make baseimage a argument

### DIFF
--- a/kinetic/Dockerfile
+++ b/kinetic/Dockerfile
@@ -1,5 +1,6 @@
-# Ubuntu 18.04 with nvidia-docker2 beta opengl support.
-FROM ros:kinetic-ros-base
+# Base Image
+ARG BASEIMG=ros:kinetic-ros-base
+FROM $BASEIMG
 
 # Set Ubuntu release
 ARG RELEASE=xenial
@@ -10,7 +11,7 @@ ARG DIST=kinetic
 # Set Gazebo verison
 ARG GAZ=gazebo7
 
-# Required utilities 
+# Required utilities
 RUN apt update \
  && apt install -y --no-install-recommends \
         build-essential \
@@ -18,7 +19,6 @@ RUN apt update \
         cppcheck \
         curl \
         git \
-        gnupg \
         libeigen3-dev \
         libgles2-mesa-dev \
         lsb-release \
@@ -83,7 +83,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-xacro \
  && apt clean
 
-RUN apt install -y --no-install-recommends python3-numpy 
+RUN apt install -y --no-install-recommends python3-numpy
 
 # Optional: Dev. tools, applications, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/melodic/Dockerfile
+++ b/melodic/Dockerfile
@@ -1,5 +1,6 @@
-# Ubuntu 18.04 with nvidia-docker2 beta opengl support.
-FROM ros:melodic-ros-base
+# Base Image
+ARG BASEIMG=ros:melodic-ros-base
+FROM $BASEIMG
 
 # Set Ubuntu release
 ARG RELEASE=bionic
@@ -10,7 +11,7 @@ ARG DIST=melodic
 # Set Gazebo verison
 ARG GAZ=gazebo9
 
-# Required utilities 
+# Required utilities
 RUN apt update \
  && apt install -y --no-install-recommends \
         build-essential \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -1,5 +1,6 @@
-# Ubuntu 20.04 with nvidia-docker2 beta opengl support.
-FROM ros:noetic-ros-base
+# Base Image
+ARG BASEIMG=ros:noetic-ros-base
+FROM $BASEIMG
 
 # Set Ubuntu release
 ARG RELEASE=focal
@@ -18,7 +19,6 @@ RUN apt update \
         cppcheck \
         curl \
         git \
-        gnupg \
         libeigen3-dev \
         libgles2-mesa-dev \
         lsb-release \


### PR DESCRIPTION
## Remove out-of-date comment
```
# Ubuntu 20.04 with nvidia-docker2 beta opengl support.
```
comment is a leftover from the previous template I've wrote. It should be removed.

## Make base image a argument variable.
I've made a baseimage variable to be argument.

## Plan for building a multibeam sonar (cuda ready) docker image
- It's a plan! not included in this PR.
- Changing the base image in the dockerfile allows to run multibeam sonar plugin.
- [cuda PR (currently at a draft state)](https://github.com/osrf/rocker/pull/126) at rocker will make this plan obsolete.

A [`cuda` branch](https://github.com/Field-Robotics-Lab/dockwater/tree/cuda) simply changes the base image for melodic and noetic dockerfile. At out dave's [docker development image](https://github.com/Field-Robotics-Lab/dave/wiki/Docker-Development-Image) wiki, user only needs to add `-b cuda` when they clone this dockwater repository.