### PR TITLE
adding convenience script for build+run combo

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (C) 2018 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A convenience script for building and running dockwater images
+# Defaults to using the noetic image
+image_name="noetic"
+
+if [ $# -lt 1 ]
+then
+    echo "Building and running default image <${image_name}>"
+else
+    image_name=$(basename $1)
+fi
+
+./build.bash $image_name && \
+./run.bash $image_name:latest

--- a/join.bash
+++ b/join.bash
@@ -2,6 +2,8 @@
 #
 # Typical usage: ./join.bash <container_name>
 #
+# Note that running: docker container ls
+# will give a list of running containers.
 
 CONTAINER_ID=$1
 


### PR DESCRIPTION
This PR adds a simple wrapper that calls the build and run scripts successively using some likely default arguments. Some advantages:
* If the image has already been built, Docker will detect this and won't built again.
* If the Dockerfile is edited, Docker will detect this and update it.
* We can set a default image to noetic because we know this is in the repository.
* We always know what we used for the tag, so we can re-use this when calling run.bash.