### PR TITLE
Cuda-dev update for multibeam sonar plugin

### DIFF
--- a/kinetic/Dockerfile
+++ b/kinetic/Dockerfile
@@ -9,7 +9,7 @@ ARG DIST=kinetic
 # Set Gazebo verison
 ARG GAZ=gazebo7
 
-# Required utilities 
+# Required utilities
 RUN apt update \
  && apt install -y --no-install-recommends \
         build-essential \
@@ -82,15 +82,18 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-velodyne-gazebo-plugins \
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-xacro \
+    ros-${DIST}-pcl-ros \
+    ros-${DIST}-image-view \
  && apt clean
 
-RUN apt install -y --no-install-recommends python3-numpy 
+RUN apt install -y --no-install-recommends python3-numpy
 
 # Optional: Dev. tools, applications, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdb \
     psmisc \
     vim \
+    x11-apps \
     && rm -rf /var/lib/apt/lists/*
 
 ## Customize your image here.

--- a/melodic/Dockerfile
+++ b/melodic/Dockerfile
@@ -9,7 +9,7 @@ ARG DIST=melodic
 # Set Gazebo verison
 ARG GAZ=gazebo9
 
-# Required utilities 
+# Required utilities
 RUN apt update \
  && apt install -y --no-install-recommends \
         build-essential \
@@ -82,6 +82,8 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-velodyne-gazebo-plugins \
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-xacro \
+    ros-${DIST}-pcl-ros \
+    ros-${DIST}-image-view \
  && apt clean
 
 RUN pip3 install numpy

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -86,7 +86,12 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-velodyne-gazebo-plugins \
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-xacro \
+    ros-${DIST}-pcl-ros \
+    ros-${DIST}-image-view \
  && apt clean
+
+# Fix rqt_image_viewer pyqt5 problem
+RUN python3 -m pip remove pyqt5 pyqt5-sip
 
 # Optional: Dev. tools, applications, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -56,6 +56,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     python3-rosinstall \
     python3-rosinstall-generator \
     python3-vcstool \
+    catkin-lint \
     ros-${DIST}-gazebo-plugins \
     ros-${DIST}-gazebo-ros \
     ros-${DIST}-gazebo-ros-control \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -91,7 +91,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
  && apt clean
 
 # Fix rqt_image_viewer pyqt5 problem
-RUN python3 -m pip remove pyqt5 pyqt5-sip
+RUN python3 -m pip uninstall pyqt5 pyqt5-sip
 
 # Optional: Dev. tools, applications, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/run.bash
+++ b/run.bash
@@ -49,7 +49,7 @@ ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 while getopts ":csth" option; do
   case $option in
     c) # enable cuda library support
-      CUDA="--cuda-dev ";;
+      CUDA="--cuda";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration

--- a/run.bash
+++ b/run.bash
@@ -49,12 +49,12 @@ ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 while getopts ":csth" option; do
   case $option in
     c) # enable cuda library support 
-      CUDA="--cuda ";;
+      CUDA="--cuda-dev ";;
     s) # Build cloudsim image
-      ROCKER_ARGS="--cuda --nvidia --novnc --turbovnc --user --user-override-name=developer";;
+      ROCKER_ARGS="--cuda-dev --nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
       echo "Building CI image"
-      ROCKER_ARGS="--cuda --dev-helpers --nvidia --user --user-override-name=developer";;
+      ROCKER_ARGS="--cuda-dev --dev-helpers --nvidia --user --user-override-name=developer";;
     h) # print this help message and exit
       Help
       exit;; 

--- a/run.bash
+++ b/run.bash
@@ -45,7 +45,7 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
+ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --volume /dev:/dev --user --home --git"
 
 while getopts ":cstxh" option; do
   case $option in

--- a/run.bash
+++ b/run.bash
@@ -48,16 +48,16 @@ ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
 while getopts ":csth" option; do
   case $option in
-    c) # enable cuda library support 
+    c) # enable cuda library support
       CUDA="--cuda-dev ";;
     s) # Build cloudsim image
-      ROCKER_ARGS="--cuda-dev --nvidia --novnc --turbovnc --user --user-override-name=developer";;
-    t) # Build test image for Continuous Integration 
+      ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
+    t) # Build test image for Continuous Integration
       echo "Building CI image"
-      ROCKER_ARGS="--cuda-dev --dev-helpers --nvidia --user --user-override-name=developer";;
+      ROCKER_ARGS="--dev-helpers --nvidia --user --user-override-name=developer";;
     h) # print this help message and exit
       Help
-      exit;; 
+      exit;;
   esac
 done
 
@@ -69,4 +69,4 @@ CONTAINER_NAME="${NAMES[0]}_runtime"
 ROCKER_ARGS="${ROCKER_ARGS} --name $CONTAINER_NAME"
 echo "Using image <$IMG_NAME> to start container <$CONTAINER_NAME>"
 
-rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME 
+rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME

--- a/run.bash
+++ b/run.bash
@@ -48,16 +48,16 @@ ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
 while getopts ":csth" option; do
   case $option in
-    c) # enable cuda library support 
-      CUDA="--cuda ";;
+    c) # enable cuda library support
+      CUDA="--cuda-dev ";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
-    t) # Build test image for Continuous Integration 
+    t) # Build test image for Continuous Integration
       echo "Building CI image"
       ROCKER_ARGS="--dev-helpers --nvidia --user --user-override-name=developer";;
     h) # print this help message and exit
       Help
-      exit;; 
+      exit;;
   esac
 done
 
@@ -69,4 +69,4 @@ CONTAINER_NAME="${NAMES[0]}_runtime"
 ROCKER_ARGS="${ROCKER_ARGS} --name $CONTAINER_NAME"
 echo "Using image <$IMG_NAME> to start container <$CONTAINER_NAME>"
 
-rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME 
+rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME


### PR DESCRIPTION
(modified 2022/7/20)
The [rocker `cuda` PR](https://github.com/osrf/rocker/pull/126) is now merged. This PR includes necessary changes to run multibeam sonar.

## How-to (updated to use virtual environment (venv) of pip 2022/5/9)
```
# Install virtual environment (venv) for pip
sudo apt-get install python3-venv

# Create a venv
mkdir -p ~/rocker_venv_cuda
python3 -m venv ~/rocker_venv_cuda

# initiate venv
. ~/rocker_venv_cuda/bin/activate

# Clone rocker of osrf if not installed
cd ~/rocker_venv_cuda
git clone https://github.com/osrf/rocker.git
cd rocker

# install
sudo pip install .

# change dockwater to cuda-dev branch
cd ~/uuv_ws/src/dockwater
git checkout cuda-dev

# Build and run docker image
./build.bash noetic
./run.bash -c noetic:latest

# Clone necessary repos for multibeam sonar
cd ~/uuv_ws/src
vcs import --skip-existing --input dave/extras/repos/multibeam_sim.repos .

# Clean previous compiles (optional)
cd ~/uuv_ws
rm -rf build devel
rm src/CMakeLists.txt

# Compile and run tutorial case
cd ~/uuv_ws
catkin_make
source ~/uuv_ws/devel/setup.bash
roslaunch nps_uw_multibeam_sonar sonar_tank_blueview_p900_nps_multibeam.launch
```