### PR TITLE
Add osrf-pycommon dependency for catkin build command

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -95,6 +95,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     vim \
     && rm -rf /var/lib/apt/lists/*
 
+# For catkin build
+RUN pip3 install osrf-pycommon
+
 ## Customize your image here.
 #
 #


### PR DESCRIPTION
To address https://github.com/Field-Robotics-Lab/dave/issues/148

Theoretically, according to [this](https://catkin-tools.readthedocs.io/en/latest/installing.html), what's in the Dockerfile (`python3-catkin-tools`) should already work, but I get an error and have to additionally install this:
```
pip3 install osrf-pycommon
```

## To test

DAVE's setup compiles with this out of the box.

Build the `noetic` Dockerfile and run it, then go to DAVE repo, compile with
```
catkin build
```