### PR TITLE
Rename image to dockwater:<distro>

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -18,7 +18,8 @@
 #
 
 # Builds a Docker image.
-image_name=$(basename $1)
+image_name=dockwater
+distro=$(basename $1)
 
 if [ $# -lt 1 ]
 then
@@ -34,7 +35,7 @@ fi
 
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
 docker build --rm -t $image_plus_tag -f "${1}"/Dockerfile "${1}" && \
-docker tag $image_plus_tag $image_name:latest && \
-echo "Built $image_plus_tag and tagged as $image_name:latest"
+docker tag $image_plus_tag $image_name:$distro && \
+echo "Built $image_plus_tag and tagged as $image_name:$distro"
 echo "To run:"
-echo "./run.bash $image_name:latest"
+echo "./run.bash $image_name:$distro"


### PR DESCRIPTION
This is a best practices suggestion to rename the Docker image to be more descriptive, so that it's less confusing for people who have many Docker images from different projects.

## Before
Currently, if I run `docker images`, the `dockwater` images appear as:
```
$ docker images
REPOSITORY                   TAG                            IMAGE ID       CREATED             SIZE
noetic                       2022_01_19_2202                b7ac7719a40d   About an hour ago   3.28GB
noetic                       latest                         b7ac7719a40d   About an hour ago   3.28GB
noetic                       2022_01_19_2146                9bdd2e35cbc4   2 hours ago         3.23GB
```

That's not descriptive of what the image is at all. The name tells me it's an image of just ROS Noetic, as in, specifically giving me a clean ROS Noetic to put anything on ROS. But it isn't.

## What other people do
Other official images take on names like:
```
nvidia/opengl                1.0-glvnd-devel-ubuntu18.04    b2c661301c99   16 months ago       414MB
ubuntu                       focal                          a3282b72a167   22 months ago       73.8MB
ubuntu                       bionic                         4e5021d210f6   22 months ago       64.2MB
```
where the REPOSITORY tells what it is, and the TAG tells the version or distro.

## After
In this PR, I suggest calling the image `dockwater:<distro>`. The result looks like this:
```
dockwater                    2022_01_19_2320                5c1e24c65b73   2 hours ago         3.23GB
dockwater                    noetic                         5c1e24c65b73   2 hours ago         3.23GB
```

If people don't like that, it could be alternatively, `dockwater_<distro>:latest`.

I would really prefer it to be anything but just `noetic:latest`. That's really confusing to me.