### PR TITLE
Add MoveIt and ros-controller dependencies to noetic Dockerfile

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -73,6 +73,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-move-base \
     ros-${DIST}-moveit-planners \
     ros-${DIST}-moveit-simple-controller-manager \
+    ros-${DIST}-moveit-ros-visualization \
     ros-${DIST}-robot-localization \
     ros-${DIST}-robot-state-publisher \
     ros-${DIST}-ros-base \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -71,6 +71,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-kdl-parser-py \
     ros-${DIST}-key-teleop \
     ros-${DIST}-move-base \
+    ros-${DIST}-moveit-commander \
     ros-${DIST}-moveit-planners \
     ros-${DIST}-moveit-simple-controller-manager \
     ros-${DIST}-moveit-ros-visualization \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -71,9 +71,11 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-kdl-parser-py \
     ros-${DIST}-key-teleop \
     ros-${DIST}-move-base \
+    ros-${DIST}-moveit* \
     ros-${DIST}-robot-localization \
     ros-${DIST}-robot-state-publisher \
     ros-${DIST}-ros-base \
+    ros-${DIST}-ros-controllers \
     ros-${DIST}-rqt \
     ros-${DIST}-rqt-common-plugins \
     ros-${DIST}-rqt-robot-plugins \

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -71,7 +71,8 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     ros-${DIST}-kdl-parser-py \
     ros-${DIST}-key-teleop \
     ros-${DIST}-move-base \
-    ros-${DIST}-moveit* \
+    ros-${DIST}-moveit-planners \
+    ros-${DIST}-moveit-simple-controller-manager \
     ros-${DIST}-robot-localization \
     ros-${DIST}-robot-state-publisher \
     ros-${DIST}-ros-base \


### PR DESCRIPTION
To test, run ```roslaunch dave_demo_launch dave_two_arm_demo.launch```
Once the Gazebo window has opened and controllers loaded, run
```roslaunch oberon7_moveit_config oberon7_multi_planning_execution.launch```
This should bring up two RViz windows which can be used to control the two arms in the Gazebo environment.

OLD:
Required by field-robotics-lab/dave#206 and field-robotics-lab/uuv_manipulators#8.

Quick way to get MoveIt requirements, though possibly overkill.
