### PR TITLE
Adding humble/garden support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Docker images used across multiple repositories supporting simulation of water-r
 ## Distributions
 This repository supports baseline images for running Gazebo on the following ROS distributions:
 
+* Humble (Ubuntu 22.04 Jammy Jellyfish / ROS 2 Humble Hawksbill / Gazebo Garden)
 * Galactic (Ubuntu 20.04 Focal Fossa / ROS 2 Galactic Geochelone / Ignition Fortress)
 * Noetic (Ubuntu 20.04 Focal Fossa / ROS Noetic Ninjemys / Gazebo 11)
 * Melodic (Ubuntu 18.04 Bionic Beaver / ROS Melodic Morenia / Gazebo 9)

--- a/README.md
+++ b/README.md
@@ -1,36 +1,3 @@
-
-
-# Required utilities
-RUN apt update \
- && apt install -y --no-install-recommends \
-        build-essential \
-	ca-certificates \	
-        cmake \
-        cppcheck \
-        curl \
-        git \
-        gnupg2 \
-        libeigen3-dev \
-        libgflags-dev \
-        libgles2-mesa-dev \
-        lsb-release \
-        pkg-config \
-        protobuf-compiler \
-        python3-dbg \
-        python3-colcon-common-extensions \
-        python3-pip \
-        python3-scipy \
-        python3-vcstool \
-        python3-venv \
-        qtbase5-dev \
-        ruby \
-        software-properties-common \
-        sudo \
-	tzdata \
-        wget \
- && apt -qq clean
-
-
 # dockwater
 Docker images used across multiple repositories supporting simulation of water-related robotics
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
+
+
+# Required utilities
+RUN apt update \
+ && apt install -y --no-install-recommends \
+        build-essential \
+	ca-certificates \	
+        cmake \
+        cppcheck \
+        curl \
+        git \
+        gnupg2 \
+        libeigen3-dev \
+        libgflags-dev \
+        libgles2-mesa-dev \
+        lsb-release \
+        pkg-config \
+        protobuf-compiler \
+        python3-dbg \
+        python3-colcon-common-extensions \
+        python3-pip \
+        python3-scipy \
+        python3-vcstool \
+        python3-venv \
+        qtbase5-dev \
+        ruby \
+        software-properties-common \
+        sudo \
+	tzdata \
+        wget \
+ && apt -qq clean
+
+
 # dockwater
 Docker images used across multiple repositories supporting simulation of water-related robotics
 
 ## Distributions
 This repository supports baseline images for running Gazebo on the following ROS distributions:
+
+* Galactic (Ubuntu 20.04 Focal Fossa / ROS 2 Galactic Geochelone / Ignition Fortress)
 * Noetic (Ubuntu 20.04 Focal Fossa / ROS Noetic Ninjemys / Gazebo 11)
 * Melodic (Ubuntu 18.04 Bionic Beaver / ROS Melodic Morenia / Gazebo 9)
 * Kinetic (Ubuntu 18.04 Xenial Xerus / ROS Kinetic Kame / Gazebo 7)

--- a/galactic/Dockerfile
+++ b/galactic/Dockerfile
@@ -51,8 +51,6 @@ RUN apt-get update && \
 	xvfb \
  && apt-get clean -qq
 
-
-
 # Setup locale
 RUN sudo apt update && sudo apt install locales \
   && sudo locale-gen en_US en_US.UTF-8 \
@@ -75,7 +73,7 @@ RUN apt-get update \
   && apt-get clean -qq
 
 # Install rosdep
-RUN apt-get update \
+RUN apt update \
   && apt install -y python3-rosdep \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean -qq \
@@ -93,7 +91,6 @@ RUN apt update \
      ros-${ROSDIST}-image-transport \
      ros-${ROSDIST}-mavros-msgs \
      ros-${ROSDIST}-image-transport-plugins \
-     ros-${ROSDIST}-ros-ign \
      ros-${ROSDIST}-rqt-graph \
      ros-${ROSDIST}-rqt-image-view \
      ros-${ROSDIST}-rqt-plot \
@@ -102,4 +99,11 @@ RUN apt update \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq
 
+# Beware - don't install this: ros-${ROSDIST}-ros-ign
+# For MBZIRC this causes errors such as
+# [ign gazebo-1] Error [Converter.cc:156] Unable to convert from SDF version 1.9 to 1.8
+# [ign gazebo-1] [Err] [SystemLoader.cc:66] Failed to load system plugin [ignition-gazebo-forcetorque-system] : couldn't find shared library.
+#[ign gazebo-1] [Err] [SystemLoader.cc:66] Failed to load system plugin [ignition-gazebo-rf-comms-system] : couldn't find shared library.
+
 ## Customize your image here.
+

--- a/galactic/Dockerfile
+++ b/galactic/Dockerfile
@@ -1,0 +1,111 @@
+# Ubuntu 20.04 with nvidia-docker2 beta opengl support
+# This is what MBZIRC uses as a base.
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu20.04
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+    sudo \
+    wget \
+    gnupg2 \
+    lsb-release \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -qq clean
+
+  
+# Setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+  && apt-get -qq update && apt-get -q -y install tzdata \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -qq clean
+
+# Tools useful during development
+RUN apt-get update -qq \
+ && apt-get install --no-install-recommends -y -qq \
+        build-essential \
+        atop \
+        cmake \
+        cppcheck \
+	curl \
+        expect \
+        gdb \
+        git \
+	gnupg2 \
+        gnutls-bin \
+	iputils-ping \
+        libbluetooth-dev \
+        libccd-dev \
+        libcwiid-dev \
+	libeigen3-dev \
+        libfcl-dev \
+        libgflags-dev \
+        libgles2-mesa-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+	net-tools \
+	pkg-config \
+        protobuf-compiler \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-setuptools \
+        python3-pip \
+        python3-venv \
+        software-properties-common \
+        vim \
+	xvfb \
+ && apt-get clean -qq
+
+# Setup locale
+RUN sudo apt update && sudo apt install locales \
+  && sudo locale-gen en_US en_US.UTF-8 \
+  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+# Set up ros2 repo
+RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
+  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null'
+
+ARG ROSDIST=galactic
+ARG IGNDIST=fortress
+
+# Install ignition fortress and ROS2 Desktop
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     ignition-${IGNDIST} \
+     ros-${ROSDIST}-desktop \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq
+
+# Install rosdep
+RUN apt-get update \
+  && apt install -y python3-rosdep \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq \
+  && rosdep init \
+  && rosdep update
+
+# Install some 'standard' ROS packages and utilities.
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     python3-colcon-common-extensions \
+     python3-vcstool \
+     ros-${ROSDIST}-radar-msgs \
+     ros-${ROSDIST}-ament-cmake-pycodestyle \
+     ros-${ROSDIST}-xacro \
+     ros-${ROSDIST}-image-transport \
+     ros-${ROSDIST}-mavros-msgs \
+     ros-${ROSDIST}-image-transport-plugins \
+     ros-${ROSDIST}-ros-ign \
+     ros-${ROSDIST}-rqt-graph \
+     ros-${ROSDIST}-rqt-image-view \
+     ros-${ROSDIST}-rqt-plot \
+     ros-${ROSDIST}-rqt-topic \
+     ros-${ROSDIST}-rviz2 \
+  && sudo rm -rf /var/lib/apt/lists/* \
+  && sudo apt-get clean -qq
+
+ENV IGNITION_VERSION fortress
+
+## Customize your image here.

--- a/galactic/Dockerfile
+++ b/galactic/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && \
         python3-setuptools \
         python3-pip \
         python3-venv \
+	ruby \
         software-properties-common \
 	sudo \
         vim \
@@ -53,9 +54,9 @@ RUN apt-get update && \
 
 
 # Setup locale
-#RUN sudo apt update && sudo apt install locales \
-#  && sudo locale-gen en_US en_US.UTF-8 \
-#  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN sudo apt update && sudo apt install locales \
+  && sudo locale-gen en_US en_US.UTF-8 \
+  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 # Set up ros2 repo
 RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \

--- a/galactic/Dockerfile
+++ b/galactic/Dockerfile
@@ -1,6 +1,5 @@
-# Ubuntu 20.04 with nvidia-docker2 beta opengl support
-# This is what MBZIRC uses as a base.
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu20.04
+# Ubuntu 20.04 
+FROM ros:galactic-ros-base-focal
 
 # Setup timezone
 ENV TZ=Etc/UTC
@@ -56,10 +55,6 @@ RUN sudo apt update && sudo apt install locales \
   && sudo locale-gen en_US en_US.UTF-8 \
   && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
-# Set up ros2 repo
-RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
-  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null'
-
 ARG ROSDIST=galactic
 ARG IGNDIST=fortress
 ENV IGNITION_VERSION fortress
@@ -71,14 +66,6 @@ RUN apt-get update \
      ros-${ROSDIST}-desktop \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean -qq
-
-# Install rosdep
-RUN apt update \
-  && apt install -y python3-rosdep \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean -qq \
-  && rosdep init \
-  && rosdep update
 
 # Install some 'standard' ROS packages and utilities.
 RUN apt update \
@@ -98,12 +85,6 @@ RUN apt update \
      ros-${ROSDIST}-rviz2 \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq
-
-# Beware - don't install this: ros-${ROSDIST}-ros-ign
-# For MBZIRC this causes errors such as
-# [ign gazebo-1] Error [Converter.cc:156] Unable to convert from SDF version 1.9 to 1.8
-# [ign gazebo-1] [Err] [SystemLoader.cc:66] Failed to load system plugin [ignition-gazebo-forcetorque-system] : couldn't find shared library.
-#[ign gazebo-1] [Err] [SystemLoader.cc:66] Failed to load system plugin [ignition-gazebo-rf-comms-system] : couldn't find shared library.
 
 ## Customize your image here.
 

--- a/galactic/Dockerfile
+++ b/galactic/Dockerfile
@@ -2,29 +2,18 @@
 # This is what MBZIRC uses as a base.
 FROM nvidia/opengl:1.0-glvnd-devel-ubuntu20.04
 
-RUN apt-get update \
- && apt-get install --no-install-recommends -y \
-    sudo \
-    wget \
-    gnupg2 \
-    lsb-release \
-    ca-certificates \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get -qq clean
-
-  
 # Setup timezone
-RUN echo 'Etc/UTC' > /etc/timezone && \
-  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-  && apt-get -qq update && apt-get -q -y install tzdata \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get -qq clean
-
-# Tools useful during development
-RUN apt-get update -qq \
- && apt-get install --no-install-recommends -y -qq \
+ENV TZ=Etc/UTC
+RUN echo $TZ > /etc/timezone && \
+  ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
+  
+# Tools necessary and useful during development
+RUN apt-get update && \
+ DEBIAN_FRONTEND=noninteractive \
+ apt-get install --no-install-recommends -y \
         build-essential \
         atop \
+	ca-certificates \
         cmake \
         cppcheck \
 	curl \
@@ -44,6 +33,7 @@ RUN apt-get update -qq \
         libgoogle-glog-dev \
         libspnav-dev \
         libusb-dev \
+	lsb-release \
 	net-tools \
 	pkg-config \
         protobuf-compiler \
@@ -54,14 +44,18 @@ RUN apt-get update -qq \
         python3-pip \
         python3-venv \
         software-properties-common \
+	sudo \
         vim \
+	wget \
 	xvfb \
  && apt-get clean -qq
 
+
+
 # Setup locale
-RUN sudo apt update && sudo apt install locales \
-  && sudo locale-gen en_US en_US.UTF-8 \
-  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+#RUN sudo apt update && sudo apt install locales \
+#  && sudo locale-gen en_US en_US.UTF-8 \
+#  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 # Set up ros2 repo
 RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
@@ -69,6 +63,7 @@ RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master
 
 ARG ROSDIST=galactic
 ARG IGNDIST=fortress
+ENV IGNITION_VERSION fortress
 
 # Install ignition fortress and ROS2 Desktop
 RUN apt-get update \
@@ -105,7 +100,5 @@ RUN apt update \
      ros-${ROSDIST}-rviz2 \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq
-
-ENV IGNITION_VERSION fortress
 
 ## Customize your image here.

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -1,0 +1,91 @@
+# Ubuntu 20.04 
+FROM ros:humble-ros-base-jammy
+
+# Setup timezone
+ENV TZ=Etc/UTC
+RUN echo $TZ > /etc/timezone && \
+  ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
+  
+# Tools necessary and useful during development
+RUN apt-get update && \
+ DEBIAN_FRONTEND=noninteractive \
+ apt-get install --no-install-recommends -y \
+        build-essential \
+        atop \
+	ca-certificates \
+        cmake \
+        cppcheck \
+	curl \
+        expect \
+        gdb \
+        git \
+	gnupg2 \
+        gnutls-bin \
+	iputils-ping \
+        libbluetooth-dev \
+        libccd-dev \
+        libcwiid-dev \
+	libeigen3-dev \
+        libfcl-dev \
+        libgflags-dev \
+        libgles2-mesa-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+	lsb-release \
+	net-tools \
+	pkg-config \
+        protobuf-compiler \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-setuptools \
+        python3-pip \
+        python3-venv \
+	ruby \
+        software-properties-common \
+	sudo \
+        vim \
+	wget \
+	xvfb \
+ && apt-get clean -qq
+
+# Setup locale
+RUN sudo apt update && sudo apt install locales \
+  && sudo locale-gen en_US en_US.UTF-8 \
+  && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ARG ROSDIST=humble
+ARG GZDIST=garden
+ENV IGNITION_VERSION garden
+
+# Set up repo to install Ignition
+RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg' \
+  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null'
+  
+# Install Gazebo and ROS2 Desktop
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     gz-${GZDIST} \
+     ros-${ROSDIST}-desktop \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq
+
+# Install some 'standard' ROS packages and utilities.
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     python3-colcon-common-extensions \
+     python3-vcstool \
+     ros-${ROSDIST}-radar-msgs \
+     ros-${ROSDIST}-ament-cmake-pycodestyle \
+     ros-${ROSDIST}-xacro \
+     ros-${ROSDIST}-image-transport \
+     ros-${ROSDIST}-mavros-msgs \
+     ros-${ROSDIST}-image-transport-plugins \
+     ros-${ROSDIST}-rqt-graph \
+     ros-${ROSDIST}-rqt-image-view \
+     ros-${ROSDIST}-rqt-plot \
+     ros-${ROSDIST}-rqt-topic \
+     ros-${ROSDIST}-rviz2 \
+  && sudo rm -rf /var/lib/apt/lists/* \
+  && sudo apt-get clean -qq

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -57,7 +57,7 @@ RUN sudo apt update && sudo apt install locales \
 
 ARG ROSDIST=humble
 ARG GZDIST=garden
-ENV IGNITION_VERSION garden
+ENV GZ_VERSION garden
 
 # Set up repo to install Ignition
 RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg' \

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -39,7 +39,6 @@ RUN apt update && \
         python3-dbg \
         python3-empy \
         python3-numpy \
-        python3-sdformat13 \
         python3-setuptools \
         python3-pip \
         python3-venv \
@@ -77,6 +76,7 @@ RUN apt update \
   && apt install -y --no-install-recommends \
      python3-colcon-common-extensions \
      python3-vcstool \
+     python3-sdformat13 \
      ros-${ROSDIST}-radar-msgs \
      ros-${ROSDIST}-ament-cmake-pycodestyle \
      ros-${ROSDIST}-xacro \

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -39,6 +39,7 @@ RUN apt update && \
         python3-dbg \
         python3-empy \
         python3-numpy \
+        python3-sdformat13 \
         python3-setuptools \
         python3-pip \
         python3-venv \

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -1,4 +1,4 @@
-# Ubuntu 20.04 
+# Ubuntu 22.04 
 FROM ros:humble-ros-base-jammy
 
 # Setup timezone

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -7,9 +7,9 @@ RUN echo $TZ > /etc/timezone && \
   ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
   
 # Tools necessary and useful during development
-RUN apt-get update && \
+RUN apt update && \
  DEBIAN_FRONTEND=noninteractive \
- apt-get install --no-install-recommends -y \
+ apt install --no-install-recommends -y \
         build-essential \
         atop \
 	ca-certificates \
@@ -48,7 +48,7 @@ RUN apt-get update && \
         vim \
 	wget \
 	xvfb \
- && apt-get clean -qq
+ && apt clean -qq
 
 # Setup locale
 RUN sudo apt update && sudo apt install locales \
@@ -87,5 +87,7 @@ RUN apt update \
      ros-${ROSDIST}-rqt-plot \
      ros-${ROSDIST}-rqt-topic \
      ros-${ROSDIST}-rviz2 \
+     ros-${ROSDIST}-joy-teleop \
+     ros-${ROSDIST}-joy-linux \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq

--- a/run.bash
+++ b/run.bash
@@ -37,6 +37,7 @@ Help()
    echo "c     Add cuda library support."
    echo "s     Create an image with novnc for use with cloudsim."
    echo "t     Create a test image for use with CI pipelines."
+   echo "x     Create base image for the VRX competition server."
    echo "h     Print this help message and exit."
    echo
 }
@@ -46,7 +47,7 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
-while getopts ":csth" option; do
+while getopts ":cstxh" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda ";;
@@ -55,6 +56,9 @@ while getopts ":csth" option; do
     t) # Build test image for Continuous Integration 
       echo "Building CI image"
       ROCKER_ARGS="--dev-helpers --nvidia --user --user-override-name=developer";;
+    x) # Build VRX Competition base image
+      echo "Building VRX Competition server base image"
+      ROCKER_ARGS="--dev-helpers --devices $JOY --nvidia --x11 --user --user-override-name=developer";;
     h) # print this help message and exit
       Help
       exit;; 


### PR DESCRIPTION
This PR adds a Dockerfile for Humble (Ubuntu 22.04 Jammy Jellyfish / ROS 2 Humble Hawksbill / Gazebo Garden).

Test using VRX by...

1. Build the dockwater image in the usual way.
2. Build VRX - https://github.com/osrf/vrx/wiki/2023-installation
3. And run the VRX demo - https://github.com/osrf/vrx/wiki/2023-running_vrx