### PR TITLE
adding dependency to address upstream change to ros_gz

### DIFF
--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -77,6 +77,7 @@ RUN apt update \
      python3-colcon-common-extensions \
      python3-vcstool \
      python3-sdformat13 \
+     ros-${ROSDIST}-actuator-msgs \
      ros-${ROSDIST}-radar-msgs \
      ros-${ROSDIST}-ament-cmake-pycodestyle \
      ros-${ROSDIST}-xacro \


### PR DESCRIPTION
See https://github.com/gazebosim/ros_gz/issues/397. This adds the necessary dependency manually. 

To test:
* Make sure [dependencies are installed](https://github.com/Field-Robotics-Lab/dockwater/wiki/Install-Dependencies)
* Build with:
```
git clone https://github.com/Field-Robotics-Lab/dockwater.git
cd dockwater
./build.bash humble
```
* Run with rocker:
```
./run.bash dockwater:humble
```
* In the terminal, follow the instructions to install and run VRX:
  * [Install](https://github.com/osrf/vrx/wiki/installation_tutorial)
  * [Run](https://github.com/osrf/vrx/wiki/running_vrx_tutorial)