### PR TITLE
Add internal graphics option and unrecognized opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Docker images used across multiple repositories supporting simulation of water-r
 ## Distributions
 This repository supports baseline images for running Gazebo on the following ROS distributions:
 
+* Jazzy (Ubuntu 24.04 Noble Numbat / ROS 2 Jazzy Jalisco / Gazebo Harmonic)
 * Humble (Ubuntu 22.04 Jammy Jellyfish / ROS 2 Humble Hawksbill / Gazebo Garden)
 * Galactic (Ubuntu 20.04 Focal Fossa / ROS 2 Galactic Geochelone / Ignition Fortress)
 * Noetic (Ubuntu 20.04 Focal Fossa / ROS Noetic Ninjemys / Gazebo 11)
@@ -14,9 +15,9 @@ This repository supports baseline images for running Gazebo on the following ROS
 The latest images corresponding to each of the three distributions above are stored in the [`npslearninglab/watery_robots` repository on Dockerhub](https://hub.docker.com/r/npslearninglab/watery_robots).
 
 ## Build Instructions
-Build the base image with the `build.bash` script. 
+Build the base image with the `build.bash` script.
 ```
-DIST=(noetic | melodic | kinetic)
+DIST=(jazzy | humble | galactic | noetic | melodic | kinetic)
 ./build.bash ${DIST}
 ```
 Run the image locally using the `run.bash` script:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Extending the base development environments is done by adding a branch to the re
 The latest images corresponding to each of the three distributions above are stored in the [`npslearninglab/watery_robots` repository on Dockerhub](https://hub.docker.com/r/npslearninglab/watery_robots).
 
 ## Build Instructions
-Build the base image with the `build.bash` script. 
+Build the base image with the `build.bash` script.
 ```
 DIST=(jazzy | humble | galactic | noetic | melodic | kinetic)
 ./build.bash ${DIST}

--- a/jazzy/Dockerfile
+++ b/jazzy/Dockerfile
@@ -1,0 +1,102 @@
+# Ubuntu 24.04
+FROM ros:jazzy-ros-base-noble
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup timezone
+ENV TZ=Etc/UTC
+RUN echo $TZ > /etc/timezone && \
+        ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
+
+# Tools necessary and useful during development
+RUN apt-get -q update \
+        && apt-get -q -y upgrade \
+        && apt-get -q install --no-install-recommends -y \
+        build-essential \
+        atop \
+        ca-certificates \
+        cmake \
+        cppcheck \
+        curl \
+        expect \
+        gdb \
+        git \
+        gnupg2 \
+        gnutls-bin \
+        iputils-ping \
+        libbluetooth-dev \
+        libccd-dev \
+        libcwiid-dev \
+        libeigen3-dev \
+        libfcl-dev \
+        libgflags-dev \
+        libgles2-mesa-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+        lsb-release \
+        net-tools \
+        pkg-config \
+        protobuf-compiler \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-setuptools \
+        python3-pip \
+        python3-venv \
+        ruby \
+        software-properties-common \
+        sudo \
+        vim \
+        wget \
+        xvfb \
+        && apt clean -qq
+
+# Setup locale
+RUN sudo apt update && sudo apt install locales \
+        && sudo locale-gen en_US en_US.UTF-8 \
+        && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+        && export LANG=en_US.UTF-8
+
+ARG ROSDIST=jazzy
+ARG GZDIST=harmonic
+ENV GZ_VERSION harmonic
+
+# Install Gazebo and ROS2 Desktop
+RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+        && sudo apt-get -q update \
+        && sudo apt-get -y --quiet --no-install-recommends install \
+        gz-${GZDIST} \
+        ros-${ROSDIST}-desktop \
+        && sudo apt-get autoremove -y \
+        && sudo apt-get clean -y \
+        && sudo rm -rf /var/lib/apt/lists/*
+
+# Install some 'standard' ROS packages and utilities.
+RUN sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+        && wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add - \
+        && sudo apt-get -q update \
+        && sudo apt-get -q -y upgrade \
+        && sudo apt-get -q install --no-install-recommends -y \
+        libsdformat14 \
+        python3-colcon-common-extensions \
+        python3-vcstool \
+        ros-${ROSDIST}-actuator-msgs \
+        ros-${ROSDIST}-ament-cmake-pycodestyle \
+        ros-${ROSDIST}-image-transport \
+        ros-${ROSDIST}-image-transport-plugins \
+        ros-${ROSDIST}-joy-teleop \
+        ros-${ROSDIST}-joy-linux \
+        ros-${ROSDIST}-mavros-msgs \
+        ros-${ROSDIST}-radar-msgs \
+        ros-${ROSDIST}-ros-gz \
+        ros-${ROSDIST}-rqt-graph \
+        ros-${ROSDIST}-rqt-image-view \
+        ros-${ROSDIST}-rqt-plot \
+        ros-${ROSDIST}-rqt-topic \
+        ros-${ROSDIST}-rviz2 \
+        ros-${ROSDIST}-xacro \
+        && sudo apt-get autoremove -y \
+        && sudo apt-get clean -y \
+        && sudo rm -rf /var/lib/apt/lists/*

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -57,6 +57,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${RELEASE} main" > 
     python3-rosinstall \
     python3-rosinstall-generator \
     python3-vcstool \
+    python3-colcon-common-extensions \
     ros-${DIST}-gazebo-plugins \
     ros-${DIST}-gazebo-ros \
     ros-${DIST}-gazebo-ros-control \

--- a/run.bash
+++ b/run.bash
@@ -34,10 +34,10 @@ Help()
   echo
   echo "Syntax: $(basename $0) [-p <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
   echo "options:"
+  echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
   echo "c     Add cuda library support."
   echo "i     With internal graphics card (without nvidia)"
   echo "p     Override host RDP port (follow syntax for usage, only affects -r option)"
-  echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
   echo "s     Create an image with novnc for use with cloudsim."
   echo "t     Create a test image for use with CI pipelines."
   echo "x     Create base image for the VRX competition server."

--- a/run.bash
+++ b/run.bash
@@ -32,10 +32,11 @@ Help()
    # Display Help
    echo "Runs a docker container with the image created by build.bash."
    echo
-   echo "Syntax: scriptTemplate [-c|i|s|t|h]"
+   echo "Syntax: scriptTemplate [-c|i|r|s|t|h]"
    echo "options:"
    echo "c     Add cuda library support."
    echo "i     With internal graphics card (without nvidia)"
+   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker"
    echo "s     Create an image with novnc for use with cloudsim."
    echo "t     Create a test image for use with CI pipelines."
    echo "x     Create base image for the VRX competition server."
@@ -48,12 +49,15 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
-while getopts ":cstxhi" option; do
+while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda ";;
     i) # With internal graphics card (without nvidia)
       ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --user --home --git";;
+    r) # With internal graphics card (without nvidia) and with RDP default user is docker
+      # shellcheck disable=SC2116
+      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -32,9 +32,10 @@ Help()
    # Display Help
    echo "Runs a docker container with the image created by build.bash."
    echo
-   echo "Syntax: scriptTemplate [-c|s|t|h]"
+   echo "Syntax: scriptTemplate [-c|i|s|t|h]"
    echo "options:"
    echo "c     Add cuda library support."
+   echo "i     With internal graphics card (without nvidia)"
    echo "s     Create an image with novnc for use with cloudsim."
    echo "t     Create a test image for use with CI pipelines."
    echo "x     Create base image for the VRX competition server."
@@ -47,10 +48,12 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
-while getopts ":cstxh" option; do
+while getopts ":cstxhi" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda ";;
+    i) # With internal graphics card (without nvidia)
+      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --user --home --git";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -62,6 +65,9 @@ while getopts ":cstxh" option; do
     h) # print this help message and exit
       Help
       exit;; 
+    \?) # handle unrecognized options
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1;;
   esac
 done
 

--- a/run.bash
+++ b/run.bash
@@ -34,7 +34,7 @@ Help()
   echo
   echo "Syntax: $(basename $0) [-p <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
   echo "options:"
-  echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
+  echo "r     With internal graphics card (without nvidia) and with RDP. The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)"
   echo "c     Add cuda library support."
   echo "i     With internal graphics card (without nvidia)"
   echo "p     Override host RDP port (follow syntax for usage, only affects -r option)"

--- a/run.bash
+++ b/run.bash
@@ -50,17 +50,17 @@ Help()
 JOY=/dev/input/js0
 CUDA=""
 HOST_RDP_PORT=3389
-ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/home/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume "$HOME":/home/docker/HOST"
 
 while getopts ":cstxhirP:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -88,4 +88,4 @@ CONTAINER_NAME="$(tr ':' '_' <<< "$IMG_NAME")_runtime"
 ROCKER_ARGS="${ROCKER_ARGS} --name $CONTAINER_NAME"
 echo "Using image <$IMG_NAME> to start container <$CONTAINER_NAME>"
 
-rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME 
+rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME

--- a/run.bash
+++ b/run.bash
@@ -29,35 +29,38 @@
 ############################################################
 Help()
 {
-   # Display Help
-   echo "Runs a docker container with the image created by build.bash."
-   echo
-   echo "Syntax: scriptTemplate [-c|i|r|s|t|h]"
-   echo "options:"
-   echo "c     Add cuda library support."
-   echo "i     With internal graphics card (without nvidia)"
-   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker"
-   echo "s     Create an image with novnc for use with cloudsim."
-   echo "t     Create a test image for use with CI pipelines."
-   echo "x     Create base image for the VRX competition server."
-   echo "h     Print this help message and exit."
-   echo
+  # Display Help
+  echo "Runs a docker container with the image created by build.bash."
+  echo
+  echo "Syntax: scriptTemplate [-c|i|r|s|t|h|P]"
+  echo "options:"
+  echo "c     Add cuda library support."
+  echo "i     With internal graphics card (without nvidia)"
+  echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
+  echo "s     Create an image with novnc for use with cloudsim."
+  echo "t     Create a test image for use with CI pipelines."
+  echo "x     Create base image for the VRX competition server."
+  echo "h     Print this help message and exit."
+  echo "P     Override host RDP port (usage: -P <host_port>)."
+  
+  echo
 }
 
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
+HOST_RDP_PORT=3389
+ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/home/docker/HOST"
 
-while getopts ":cstxhir" option; do
+while getopts ":cstxhirP:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -69,6 +72,8 @@ while getopts ":cstxhir" option; do
     h) # print this help message and exit
       Help
       exit;; 
+    P) # Override host RDP port
+      HOST_RDP_PORT=$OPTARG;;  
     \?) # handle unrecognized options
       echo "Invalid option: -$OPTARG" >&2
       exit 1;;

--- a/run.bash
+++ b/run.bash
@@ -47,17 +47,17 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
+ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --git --volume $(echo ~):/home/docker/HOST"
 
 while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
-      CUDA="--cuda ";;
+      CUDA="--cuda --volume $(echo ~):/home/docker/HOST";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --git --volume $(echo ~):/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -58,7 +58,8 @@ while getopts ":cstxhirp:" option; do
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/root/HOST";;
-    r) # With internal graphics card (without nvidia) and with RDP default user is docker
+    r) # With internal graphics card (without nvidia) and with RDP. 
+      # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
     s) # Build cloudsim image

--- a/run.bash
+++ b/run.bash
@@ -32,7 +32,7 @@ Help()
   # Display Help
   echo "Runs a docker container with the image created by build.bash."
   echo
-  echo "Syntax: $(basename $0) [-P <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
+  echo "Syntax: $(basename $0) [-p <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
   echo "options:"
   echo "c     Add cuda library support."
   echo "i     With internal graphics card (without nvidia)"

--- a/run.bash
+++ b/run.bash
@@ -47,14 +47,14 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --git --volume $(echo ~):/home/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
 
 while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
-      CUDA="--cuda --volume $(echo ~):/home/docker/HOST";;
+      CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --git --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;

--- a/run.bash
+++ b/run.bash
@@ -32,16 +32,16 @@ Help()
   # Display Help
   echo "Runs a docker container with the image created by build.bash."
   echo
-  echo "Syntax: scriptTemplate [-c|i|r|s|t|h|P]"
+  echo "Syntax: $(basename $0) [-P <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
   echo "options:"
   echo "c     Add cuda library support."
   echo "i     With internal graphics card (without nvidia)"
+  echo "p     Override host RDP port (follow syntax for usage, only affects -r option)"
   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
   echo "s     Create an image with novnc for use with cloudsim."
   echo "t     Create a test image for use with CI pipelines."
   echo "x     Create base image for the VRX competition server."
   echo "h     Print this help message and exit."
-  echo "P     Override host RDP port (usage: -P <host_port>)."
   
   echo
 }
@@ -52,7 +52,7 @@ CUDA=""
 HOST_RDP_PORT=3389
 ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume "$HOME":/root/HOST"
 
-while getopts ":cstxhirP:" option; do
+while getopts ":cstxhirp:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
@@ -72,8 +72,11 @@ while getopts ":cstxhirP:" option; do
     h) # print this help message and exit
       Help
       exit;; 
-    P) # Override host RDP port
-      HOST_RDP_PORT=$OPTARG;;  
+    p) # Override host RDP port
+      HOST_RDP_PORT=$OPTARG;;
+    :) #handle missing arguments
+      echo "Error: Option -$OPTARG requires an argument." >&2
+      exit 1;;  
     \?) # handle unrecognized options
       echo "Invalid option: -$OPTARG" >&2
       exit 1;;

--- a/run.bash
+++ b/run.bash
@@ -50,14 +50,14 @@ Help()
 JOY=/dev/input/js0
 CUDA=""
 HOST_RDP_PORT=3389
-ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume "$HOME":/home/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume "$HOME":/root/HOST"
 
 while getopts ":cstxhirP:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/root/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;

--- a/run.bash
+++ b/run.bash
@@ -54,10 +54,10 @@ while getopts ":cstxhir" option; do
     c) # enable cuda library support 
       CUDA="--cuda ";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --user --home --git";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -61,7 +61,7 @@ while getopts ":cstxhirp:" option; do
     r) # With internal graphics card (without nvidia) and with RDP. 
       # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST --device /dev/fuse --privileged";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -29,19 +29,21 @@
 ############################################################
 Help()
 {
-   # Display Help
-   echo "Runs a docker container with the image created by build.bash."
-   echo
-   echo "Syntax: scriptTemplate [-c|i|r|s|t|h]"
-   echo "options:"
-   echo "c     Add cuda library support."
-   echo "i     With internal graphics card (without nvidia)"
-   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker"
-   echo "s     Create an image with novnc for use with cloudsim."
-   echo "t     Create a test image for use with CI pipelines."
-   echo "x     Create base image for the VRX competition server."
-   echo "h     Print this help message and exit."
-   echo
+  # Display Help
+  echo "Runs a docker container with the image created by build.bash."
+  echo
+  echo "Syntax: scriptTemplate [-c|i|r|s|t|h|P]"
+  echo "options:"
+  echo "c     Add cuda library support."
+  echo "i     With internal graphics card (without nvidia)"
+  echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
+  echo "s     Create an image with novnc for use with cloudsim."
+  echo "t     Create a test image for use with CI pipelines."
+  echo "x     Create base image for the VRX competition server."
+  echo "h     Print this help message and exit."
+  echo "P     Override host RDP port (usage: -P <host_port>)."
+  
+  echo
 }
 
 
@@ -49,15 +51,15 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
 
-while getopts ":cstxhir" option; do
+while getopts ":cstxhirP:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -69,6 +71,8 @@ while getopts ":cstxhir" option; do
     h) # print this help message and exit
       Help
       exit;; 
+    P) # Override host RDP port
+      HOST_RDP_PORT=$OPTARG;;  
     \?) # handle unrecognized options
       echo "Invalid option: -$OPTARG" >&2
       exit 1;;

--- a/run.bash
+++ b/run.bash
@@ -49,6 +49,7 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
+HOST_RDP_PORT=3389
 ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --persist-image --volume $(echo ~):/docker/HOST"
 
 while getopts ":cstxhirp:" option; do

--- a/run.bash
+++ b/run.bash
@@ -32,16 +32,16 @@ Help()
   # Display Help
   echo "Runs a docker container with the image created by build.bash."
   echo
-  echo "Syntax: scriptTemplate [-c|i|r|s|t|h|P]"
+  echo "Syntax: $(basename $0) [-P <host_port>] [-c|i|r|s|t|h] <docker_img_name>"
   echo "options:"
   echo "c     Add cuda library support."
   echo "i     With internal graphics card (without nvidia)"
+  echo "p     Override host RDP port (follow syntax for usage, only affects -r option)"
   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker (host port $HOST_RDP_PORT)"
   echo "s     Create an image with novnc for use with cloudsim."
   echo "t     Create a test image for use with CI pipelines."
   echo "x     Create base image for the VRX competition server."
   echo "h     Print this help message and exit."
-  echo "P     Override host RDP port (usage: -P <host_port>)."
   
   echo
 }
@@ -51,7 +51,7 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
 
-while getopts ":cstxhirP:" option; do
+while getopts ":cstxhirp:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
@@ -71,8 +71,11 @@ while getopts ":cstxhirP:" option; do
     h) # print this help message and exit
       Help
       exit;; 
-    P) # Override host RDP port
-      HOST_RDP_PORT=$OPTARG;;  
+    p) # Override host RDP port
+      HOST_RDP_PORT=$OPTARG;;
+    :) #handle missing arguments
+      echo "Error: Option -$OPTARG requires an argument." >&2
+      exit 1;;  
     \?) # handle unrecognized options
       echo "Invalid option: -$OPTARG" >&2
       exit 1;;

--- a/run.bash
+++ b/run.bash
@@ -60,7 +60,7 @@ while getopts ":cstxhirp:" option; do
     r) # With internal graphics card (without nvidia) and with RDP. 
       # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST --device /dev/fuse --privileged";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -32,10 +32,11 @@ Help()
    # Display Help
    echo "Runs a docker container with the image created by build.bash."
    echo
-   echo "Syntax: scriptTemplate [-c|i|s|t|h]"
+   echo "Syntax: scriptTemplate [-c|i|r|s|t|h]"
    echo "options:"
    echo "c     Add cuda library support."
    echo "i     With internal graphics card (without nvidia)"
+   echo "r     With internal graphics card (without nvidia) and with RDP. default user is docker"
    echo "s     Create an image with novnc for use with cloudsim."
    echo "t     Create a test image for use with CI pipelines."
    echo "x     Create base image for the VRX competition server."
@@ -48,12 +49,15 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git --persist-image"
 
-while getopts ":cstxhi" option; do
+while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda ";;
     i) # With internal graphics card (without nvidia)
       ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --user --home --git";;
+    r) # With internal graphics card (without nvidia) and with RDP default user is docker
+      # shellcheck disable=SC2116
+      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -56,7 +56,7 @@ while getopts ":cstxhirP:" option; do
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/root/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;

--- a/run.bash
+++ b/run.bash
@@ -47,17 +47,17 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git --persist-image"
+ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --git --persist-image --volume $(echo ~):/home/docker/HOST"
 
 while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
-      CUDA="--cuda ";;
+      CUDA="--cuda --volume $(echo ~):/home/docker/HOST";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --git --volume $(echo ~):/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -49,18 +49,18 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --persist-image --volume $(echo ~):/docker/HOST"
 
 while getopts ":cstxhirp:" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/root/HOST";;
+      ROCKER_ARGS="--devices /dev/dri --devices $JOY --x11 --git --persist-image --volume "$HOME":/root/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP. 
       # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST --device /dev/fuse --privileged";;
+      ROCKER_ARGS="--devices /dev/dri --devices $JOY --x11 --git --persist-image --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST --device /dev/fuse --privileged";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 

--- a/run.bash
+++ b/run.bash
@@ -56,10 +56,10 @@ while getopts ":cstxhirP:" option; do
     c) # enable cuda library support 
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/home/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -87,4 +87,4 @@ CONTAINER_NAME="$(tr ':' '_' <<< "$IMG_NAME")_runtime"
 ROCKER_ARGS="${ROCKER_ARGS} --name $CONTAINER_NAME"
 echo "Using image <$IMG_NAME> to start container <$CONTAINER_NAME>"
 
-rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME 
+rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME

--- a/run.bash
+++ b/run.bash
@@ -57,7 +57,8 @@ while getopts ":cstxhirp:" option; do
       CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume "$HOME":/root/HOST";;
-    r) # With internal graphics card (without nvidia) and with RDP default user is docker
+    r) # With internal graphics card (without nvidia) and with RDP. 
+      # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
     s) # Build cloudsim image

--- a/run.bash
+++ b/run.bash
@@ -32,9 +32,10 @@ Help()
    # Display Help
    echo "Runs a docker container with the image created by build.bash."
    echo
-   echo "Syntax: scriptTemplate [-c|s|t|h]"
+   echo "Syntax: scriptTemplate [-c|i|s|t|h]"
    echo "options:"
    echo "c     Add cuda library support."
+   echo "i     With internal graphics card (without nvidia)"
    echo "s     Create an image with novnc for use with cloudsim."
    echo "t     Create a test image for use with CI pipelines."
    echo "x     Create base image for the VRX competition server."
@@ -47,10 +48,12 @@ JOY=/dev/input/js0
 CUDA=""
 ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git --persist-image"
 
-while getopts ":cstxh" option; do
+while getopts ":cstxhi" option; do
   case $option in
     c) # enable cuda library support 
       CUDA="--cuda ";;
+    i) # With internal graphics card (without nvidia)
+      ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --x11 --user --home --git";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -62,6 +65,9 @@ while getopts ":cstxh" option; do
     h) # print this help message and exit
       Help
       exit;; 
+    \?) # handle unrecognized options
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1;;
   esac
 done
 

--- a/run.bash
+++ b/run.bash
@@ -47,14 +47,14 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --git --persist-image --volume $(echo ~):/home/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri --devices $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
 
 while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support 
-      CUDA="--cuda --volume $(echo ~):/home/docker/HOST";;
+      CUDA="--cuda";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --git --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/docker/HOST";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;


### PR DESCRIPTION
## How-to
```
./run.bash -i dockwater:noetic
```

- New `-i` flag adds `--devices /dev/dri` which initiates rocker to use internal graphics. It's inherited from rocker document.
- Added case invalid option error msg

I am reviving myself through Ros-Gazebo framework and found this option is needed for students here since most of their laptops does not have external graphics card.