### PR TITLE
Install `ros_gz` from debs

### DIFF
--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -78,18 +78,18 @@ RUN apt update \
      python3-vcstool \
      python3-sdformat13 \
      ros-${ROSDIST}-actuator-msgs \
-     ros-${ROSDIST}-radar-msgs \
      ros-${ROSDIST}-ament-cmake-pycodestyle \
-     ros-${ROSDIST}-xacro \
      ros-${ROSDIST}-image-transport \
-     ros-${ROSDIST}-mavros-msgs \
      ros-${ROSDIST}-image-transport-plugins \
+     ros-${ROSDIST}-joy-teleop \
+     ros-${ROSDIST}-joy-linux \
+     ros-${ROSDIST}-mavros-msgs \
+     ros-${ROSDIST}-radar-msgs \
      ros-${ROSDIST}-rqt-graph \
      ros-${ROSDIST}-rqt-image-view \
      ros-${ROSDIST}-rqt-plot \
      ros-${ROSDIST}-rqt-topic \
      ros-${ROSDIST}-rviz2 \
-     ros-${ROSDIST}-joy-teleop \
-     ros-${ROSDIST}-joy-linux \
+     ros-${ROSDIST}-xacro \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt clean -qq

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -85,6 +85,7 @@ RUN apt update \
      ros-${ROSDIST}-joy-linux \
      ros-${ROSDIST}-mavros-msgs \
      ros-${ROSDIST}-radar-msgs \
+     ros-${ROSDIST}-ros-gzgarden \
      ros-${ROSDIST}-rqt-graph \
      ros-${ROSDIST}-rqt-image-view \
      ros-${ROSDIST}-rqt-plot \

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -64,12 +64,12 @@ RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share
   && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null'
   
 # Install Gazebo and ROS2 Desktop
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+RUN apt update \
+  && apt install -y --no-install-recommends \
      gz-${GZDIST} \
      ros-${ROSDIST}-desktop \
   && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean -qq
+  && apt clean -qq
 
 # Install some 'standard' ROS packages and utilities.
 RUN apt update \
@@ -92,4 +92,4 @@ RUN apt update \
      ros-${ROSDIST}-joy-teleop \
      ros-${ROSDIST}-joy-linux \
   && sudo rm -rf /var/lib/apt/lists/* \
-  && sudo apt-get clean -qq
+  && sudo apt clean -qq

--- a/run.bash
+++ b/run.bash
@@ -55,7 +55,7 @@ while getopts ":cstxh" option; do
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
       echo "Building CI image"
-      ROCKER_ARGS="--dev-helpers --nvidia --user --user-override-name=developer";;
+      ROCKER_ARGS="--dev-helpers --nvidia";;
     x) # Build VRX Competition base image
       echo "Building VRX Competition server base image"
       ROCKER_ARGS="--dev-helpers --devices $JOY --nvidia --x11 --user --user-override-name=developer";;


### PR DESCRIPTION
This PR updates the base docker image to use the `ros_gz` humble garden binaries, which streamlines the `vrx` build process considerably. It also makes some minor syntax tweaks to tidy up the Dockerfile.

## To test:
From the root of the repo run:
```
  ./build.bash humble
  ./run.bash dockwater:humble
```
* See [the instructions on the Wiki to build and run a `humble` image](https://github.com/Field-Robotics-Lab/dockwater/wiki) for details if needed.
* From a terminal in the resulting image, follow [the instructions on the VRX Wiki to install and run VRX](https://github.com/osrf/vrx/wiki/getting_started_tutorial). 