### PR TITLE
Feature: Option to take a custom Docker image 

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -20,6 +20,7 @@
 # Builds a Docker image.
 image_name=dockwater
 distro=$(basename $1)
+image_base=${2:-ros:$distro-ros-base-jammy}
 
 if [ $# -lt 1 ]
 then
@@ -34,7 +35,7 @@ then
 fi
 
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
-docker build --rm -t $image_plus_tag -f "${1}"/Dockerfile "${1}" && \
+docker build --rm --build-arg BASE_IMG=$image_base -t $image_plus_tag -f "${1}"/Dockerfile "${1}" && \
 docker tag $image_plus_tag $image_name:$distro && \
 echo "Built $image_plus_tag and tagged as $image_name:$distro"
 echo "To run:"

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -1,5 +1,7 @@
+ARG BASE_IMG=ros:humble-ros-base-jammy
+
 # Ubuntu 22.04 
-FROM ros:humble-ros-base-jammy
+FROM $BASE_IMG
 
 # Setup timezone
 ENV TZ=Etc/UTC
@@ -37,7 +39,7 @@ RUN apt update && \
 	pkg-config \
         protobuf-compiler \
         python3-dbg \
-        python3-empy \
+ros:$distro-ros-base-jammy        python3-empy \
         python3-numpy \
         python3-setuptools \
         python3-pip \

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -69,8 +69,8 @@ RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share
 RUN apt update \
   && apt install -y --no-install-recommends \
      gz-${GZDIST} \
-     ros-${ROSDIST}-desktop \
-  && rm -rf /var/lib/apt/lists/* \
+     ros-${ROSDIST}-ros-base \
+     && rm -rf /var/lib/apt/lists/* \
   && apt clean -qq
 
 # Install some 'standard' ROS packages and utilities.


### PR DESCRIPTION
# Issue
- Docker image is hardcoded but often want to use a different image.
- ros-desktop in apt pulls in MANY packages, majority of which are simply not needed.

Related https://github.com/Field-Robotics-Lab/dockwater/issues/32
