### PR TITLE
fix libGL error: MESA-LOADER error when running on Ubuntu 22.04

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -45,7 +45,7 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --user --home --git"
+ROCKER_ARGS="--devices $JOY --dev-helpers --nvidia --x11 --volume /dev:/dev --user --home --git"
 
 while getopts ":cstxh" option; do
   case $option in


### PR DESCRIPTION
This PR will not be necessary if https://github.com/osrf/rocker/pull/258 is merged.
Meanwhile, I am adding this PR for sake of integrity of installation process of Project Dave

On freshly install Ubuntu 22.04 Jammy LTS. Without doing anything,
I've installed rocker with,
```bash
pip3 install rocker
pip3 install --force-reinstall git+https://github.com/osrf/rocker.git@main
rocker --version
# rocker 0.2.12
```
and ran Example in README
```bash
rocker --nvidia --x11 osrf/ros:noetic-desktop-full gazebo
```
and Got error saying
```
libGL error: MESA-LOADER: failed to retrieve device information
```
When I built noetic and ran with,
```bash
./build.bash noetic
./run.bash dockwater:noetic
```
It runs ok. but when I try to open gazebo I get the same libGL error as above.

I was able to fix the problem by adding `--volume /dev:/dev` in rocker argument. which adds `-v /dev:/dev` to docker argument.

I believe the right position to add `-v /dev:/dev` is `--x11` argument tag since it wouldn't break even if /dev doesn't exist.
