### PR TITLE
Install Gazebo Harmonic from packages.osrfoundation.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [wiki](https://github.com/HonuRobotics/dockwater/wiki) for detailed use inst
 
 This project includes the following:
 
-1. Project-specific development container Dockerfiles, many of wich use ROS and Gazebo.
+1. Project-specific development container Dockerfiles, many of which use ROS and Gazebo.
 1. Bash scripts to build images and run/join containers for interactive development environment - a thin wrapper for [rocker](https://github.com/osrf/rocker) functions.
 1. Documentation on common use-cases for developing inside of docker containers.
 
@@ -15,6 +15,7 @@ This project includes the following:
 
 The `main` branch of the repository supports baseline images for with ROS and Gazebo:
 
+* Jazzy (Ubuntu 24.04 Noble Numbat / ROS 2 Jazzy Jalisco / Gazebo Harmonic)
 * Humble (Ubuntu 22.04 Jammy Jellyfish / ROS 2 Humble Hawksbill / Gazebo Garden)
 * Galactic (Ubuntu 20.04 Focal Fossa / ROS 2 Galactic Geochelone / Ignition Fortress)
 * Noetic (Ubuntu 20.04 Focal Fossa / ROS Noetic Ninjemys / Gazebo 11)
@@ -31,7 +32,7 @@ The latest images corresponding to each of the three distributions above are sto
 ## Build Instructions
 Build the base image with the `build.bash` script. 
 ```
-DIST=(noetic | melodic | kinetic)
+DIST=(jazzy | humble | galactic | noetic | melodic | kinetic)
 ./build.bash ${DIST}
 ```
 Run the image locally using the `run.bash` script:

--- a/jazzy/Dockerfile
+++ b/jazzy/Dockerfile
@@ -57,13 +57,14 @@ RUN sudo apt update && sudo apt install locales \
   && sudo locale-gen en_US en_US.UTF-8 \
   && sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
-# Set up repo to install Ignition
+# Set up repo to install Gazebo
 RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg' \
   && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null'
 
   # Install some 'standard' ROS packages and utilities.
 RUN apt update \
   && apt install -y --no-install-recommends \
+     gz-harmonic \
      python3-colcon-common-extensions \
      python3-vcstool \
      ros-${ROSDIST}-ackermann-msgs \


### PR DESCRIPTION
I'd like to propose installing Gazebo from `packages.osrfoundation.org` instead. Otherwise, the Python bindings aren't enabled.